### PR TITLE
Apache Sling links and trademark information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sling Dynamic Include
+# Dynamic Include for Apache Sling
 
 ## Purpose
 
@@ -124,6 +124,7 @@ There are also components which are created from so-called synthetic resources. 
 
 * [SDI presentation](http://www.pro-vision.de/content/medialib/pro-vision/production/adaptto/2012/adaptto2012-sling-dynamic-include-tomasz-rekaweki-pdf/_jcr_content/renditions/rendition.file/adaptto2012-sling-dynamic-include-tomasz-rekaweki.pdf) on [adaptTo() 2012](http://www.pro-vision.de/de/adaptto/adaptto-2012.html)
 * [SDI blog](http://www.cognifide.com/blogs/cq/sling-dynamic-include/) post on the Cognifide website
+* See the [Apache Sling website](http://sling.apache.org/) for the Sling reference documentation. Apache Sling, Apache and Sling are trademarks of the [Apache Software Foundation](http://apache.org).
 
 # Commercial Support
 


### PR DESCRIPTION
I have changed the main title and added a link to the Sling website and trademark information, as per http://www.apache.org/foundation/marks/ . 

Note the slight but important difference between "Sling Dynamic Include" which can imply that this is an Apache Sling module, and "Dynamic Includes for Apache Sling" which makes it clearer that this is an external add-on. 

It would be nice if you could do the same for your other repositories which refer to Apache Sling. 

Thanks in advance, and feel free to get in touch with the Sling project management committee (on behalf of which I'm making this request) at dev@sling.apache.org if needed.

(I hope this doesn't sound too formal - no big deal but it's good to get this straight)
