### PR TITLE
Added check requestPath != null

### DIFF
--- a/src/main/java/com/cognifide/cq/includefilter/DynamicIncludeFilter.java
+++ b/src/main/java/com/cognifide/cq/includefilter/DynamicIncludeFilter.java
@@ -72,7 +72,7 @@ public class DynamicIncludeFilter implements Filter {
 		final SlingHttpServletResponse slingResponse = (SlingHttpServletResponse) response;
 		final String requestPath = slingRequest.getRequestPathInfo().getResourcePath();
 		for (Configuration c : configs) {
-			if (c.isEnabled() && requestPath.startsWith(c.getBasePath())) {
+			if (c.isEnabled() && requestPath != null && requestPath.startsWith(c.getBasePath())) {
 				if (process(c, slingRequest, slingResponse, chain)) {
 					return;
 				}


### PR DESCRIPTION
If you try to load the AEM http://localhost:4502/projects.html (author instance) with Sling Dynamic Include bundle enabled you will get a nullPointerException because the resourcepath of projects.html is null.
