### PR TITLE
If comments option is on, still show comments despite required request header

### DIFF
--- a/src/main/java/com/cognifide/cq/includefilter/DynamicIncludeFilter.java
+++ b/src/main/java/com/cognifide/cq/includefilter/DynamicIncludeFilter.java
@@ -84,32 +84,7 @@ public class DynamicIncludeFilter implements Filter {
 
 	private boolean isEnabled(Configuration config, SlingHttpServletRequest request) {
 		final String requestPath = request.getRequestPathInfo().getResourcePath();
-		final String requiredHeader = config.getRequiredHeader();
-		boolean isEnabled = config.isEnabled();
-		isEnabled &= StringUtils.startsWith(requestPath, config.getBasePath());
-		isEnabled &= StringUtils.isBlank(requiredHeader) || containsHeader(requiredHeader, request);
-		return isEnabled;
-	}
-
-	private boolean containsHeader(String requiredHeader, SlingHttpServletRequest request) {
-		final String name, expectedValue;
-		if (StringUtils.contains(requiredHeader, '=')) {
-			final String split[] = StringUtils.split(requiredHeader, '=');
-			name = split[0];
-			expectedValue = split[1];
-		} else {
-			name = requiredHeader;
-			expectedValue = null;
-		}
-
-		final String actualValue = request.getHeader(name);
-		if (actualValue == null) {
-			return false;
-		} else if (expectedValue == null) {
-			return true;
-		} else {
-			return actualValue.equalsIgnoreCase(expectedValue);
-		}
+		return config.isEnabled() && StringUtils.startsWith(requestPath, config.getBasePath());
 	}
 
 	private boolean process(Configuration config, SlingHttpServletRequest slingRequest,


### PR DESCRIPTION
@trekawek 

In my use case, it is helpful to know from a local non-dispatcher fronted developer server that a resource type is being picked up by SDI, without being stubbed - as the request header lookup provides.  A dry run, if you will.

In other words, I think it would be nice to always show SDI comments, if it is enabled, regardless of how the environment is fronted.  

Feel free to add commits, and/or merge if you think this change is appropriate for your upstream.     